### PR TITLE
Added capability to read 'DELL Compatible' AC Adapters + further cleanup

### DIFF
--- a/dell_psu.h
+++ b/dell_psu.h
@@ -12,7 +12,9 @@ MIT license, check license.txt for more information
 
 //we try to read up to x bytes from the device (17 bytes is the minimum to extract the power supply wattage, voltage, & amps
 #define DELL_PSU_BYTES_TO_READ 17
-
+//For genuine/official chargers, this should be the expected response header
+// 'DELL00AC' -> ASCII decimal
+const uint8_t OFFICIAL_DELL_HEADER[8] PROGMEM = {68, 69, 76, 76, 48, 48, 65, 67};
 class DellPSU
 {
 private:
@@ -29,7 +31,7 @@ public:
   boolean psu_detected(void);
 
   //Read the data stream from the psu, return true on success
-  boolean read_data(void);
+  boolean read_data(bool allowReadingThirdPartyAdapter = true);
 
   //get the watts
   uint16_t watts(void);

--- a/examples/read_data/read_data.ino
+++ b/examples/read_data/read_data.ino
@@ -17,6 +17,9 @@ void setup() {
 }
 
 void loop() {
+  // NOTE: by default, we allow reading of non-genuine/3rd-party DELL 'compatible' adapters.
+  // if you wish to disable this, and only read DELL original adapters, replace the
+  // 'dell.read_data()' call with 'dell.read_data(false)'
   if (dell.read_data()==true)
   {
     Serial.write(dell.raw_response(), DELL_PSU_BYTES_TO_READ);


### PR DESCRIPTION
Changes:
1. Added the capability for 3rd-party DELL compatible adapters to be read, with an optional flag to disable this capability.
2. Refactored the long header check comparison with more readable and cleaner memcmp_P() call.
3. Added comment to example describing how to enable/disable 3rd-party adapter reading capability.